### PR TITLE
Loop and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
      text-decoration: none;
    }
   </style>
+   <link rel="shortcut icon" type="image/png" href="https://raw.githubusercontent.com/twitter/twemoji/gh-pages/72x72/1f525.png"/>
 </head>
 
 

--- a/index.html
+++ b/index.html
@@ -51,14 +51,14 @@
   </div>
 
   <div id="sounds">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/lJ3H_SR1dXU?autoplay=1" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/lJ3H_SR1dXU?autoplay=1&loop=1&playlist=lJ3H_SR1dXU" frameborder="0" allowfullscreen></iframe>
   </div>
 
   <div class="credits">
 
     <p>Here is an emoji yule log to enjoy during the holiday season. This is basically a javascript
       version of <a href="https://twitter.com/yulelogbot" target="_new">@yulelogbot</a> on Twitter.</p>
-  
+
     <p>
       <ul>
         <li>Fireplace image from <a href="https://www.flickr.com/photos/kambanji/4135216486">flickr user kambanji</a></li>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <title>emoji yule log</title>
   <script language="javascript" type="text/javascript" src="./libraries/p5.js"></script>
   <script src="./libraries/lodash.min.js"></script>
   <script language="javascript" type="text/javascript" src="./sketch.js"></script>


### PR DESCRIPTION
I had this casting to my telly with a ChromeCast but it fell silent after half an hour. So loop the audio.

https://developers.google.com/youtube/player_parameters?hl=en#loop

Also add a nice, toasty favicon. It's linking to the emoji's remote location. It could be stored locally, and that might be a better thing to do, but it's being loaded from that location anyway for the main flames. (Let me know if you'd like it adding locally.)

And a `<title>`.
